### PR TITLE
Add jitpack maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
             </snapshots>
             <url>https://repo.cloudnetservice.eu/repository/snapshots/</url>
         </repository>
+        <!-- Used for javalin -->
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
 


### PR DESCRIPTION
Add the jitpack maven repository to the pom.xml file in the repositories group in order to allow maven to download the javalin dependency.

Like it is mentioned here:
https://github.com/kmehrunes/javalin-jwt

This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

 * Add a maven repository

### Documentation of test results:

 * Should be good


### Related issues/discussions:

 * Fixes failing builds